### PR TITLE
Implement onbin (音便) reading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ write_to = "sympy_reading/_version.py"
 [tool.poe.tasks]
 test = "pytest"
 coverage-xml = "pytest --cov=sympy_reading --doctest-modules --cov-report=xml"
-format = "ruff format sympy_reading"
-check = "ruff check sympy_reading"
+format = "ruff format sympy_reading tests"
+check = "ruff check sympy_reading tests"
 build = [{ cmd = "python -m build" }]
 
 [tool.ruff]

--- a/sympy_reading/__init__.py
+++ b/sympy_reading/__init__.py
@@ -32,6 +32,18 @@ SCALE_READING_2 = [
     "ちょう",
     "けい",
     "がい",
+    "じょ",
+    "じょう",
+    "こう",
+    "かん",
+    "せい",
+    "さい",
+    "ごく",
+    "ごうがしゃ",
+    "あそうぎ",
+    "なゆた",
+    "ふかしぎ",
+    "むりょうたいすう",
 ]
 
 OPERATOR_READING = {
@@ -47,21 +59,64 @@ def digit_to_japanese(digit_str: str) -> str:
     return DIGIT_READING[digit_str]
 
 
-def scale_reading_1_japanese(digit_str: str, nth: int) -> str:
-    scale = SCALE_READING_1[nth]
+def scale_onbin_1(reading: str, nth: int) -> str:
+    if nth == 1:
+        if reading == "さん":
+            return "さんびゃく"
+        if reading == "ろく":
+            return "ろっぴゃく"
+        if reading == "はち":
+            return "はっぴゃく"
+    if nth == 2:
+        if reading == "さん":
+            return "さんぜん"
+        if reading == "はち":
+            return "はっせん"
 
+    scale = SCALE_READING_1[nth]
+    return f"{reading}{scale}"
+
+
+def scale_onbin_2(reading: str, nth: int) -> str:
+    if not reading:
+        return ""
+
+    if nth == 3:
+        if reading[-2:] == "いち":
+            return reading[:-2] + "いっちょう"
+        if reading[-2:] == "はち":
+            return reading[:-2] + "はっちょう"
+        if reading[-3:] == "じゅう":
+            return reading[:-3] + "じゅっちょう"
+    if nth == 4:
+        if reading[-2:] == "いち":
+            return reading[:-2] + "いっけい"
+        if reading[-2:] == "ろく":
+            return reading[:-2] + "ろっけい"
+        if reading[-2:] == "はち":
+            return reading[:-2] + "はっけい"
+        if reading[-3:] == "じゅう":
+            return reading[:-3] + "じゅっけい"
+
+    scale = SCALE_READING_2[nth]
+    return f"{reading}{scale}"
+
+
+def scale_reading_1_japanese(digit_str: str, nth: int) -> str:
     if digit_str == "1":
         reading = ""
     else:
         reading = digit_to_japanese(digit_str)
 
-    return f"{reading}{scale}"
+    onbin = scale_onbin_1(reading, nth)
+    return onbin
 
 
 def digits_to_japanese(digits_str: str, top: bool = True) -> str:
     """
     Converts a digit string to its Japanese reading.
     """
+
     if len(digits_str) == 1:
         if not top and digits_str[0] == "0":
             return ""
@@ -69,12 +124,9 @@ def digits_to_japanese(digits_str: str, top: bool = True) -> str:
 
     if len(digits_str) <= 4:
         if digits_str[0] == "0":
-            return digits_to_japanese(digits_str[1:])
-
+            return digits_to_japanese(digits_str[1:], top=False)
         reading = scale_reading_1_japanese(digits_str[0], len(digits_str) - 2)
         return f"{reading}{digits_to_japanese(digits_str[1:], top=False)}"
-
-    #     return scale_reading_1_japanese(digits_str)
 
     # Split the digits into groups of 4 from right to left
     digits_array = []
@@ -85,8 +137,9 @@ def digits_to_japanese(digits_str: str, top: bool = True) -> str:
 
     readings = []
     for i, digits in enumerate(digits_array):
-        scale_reading = SCALE_READING_2[len(digits_array) - i - 1]
-        reading = f"{digits_to_japanese(digits)}{scale_reading}"
+        nth = len(digits_array) - i - 1
+        base = digits_to_japanese(digits, top=False)
+        reading = scale_onbin_2(base, nth)
         readings.append(reading)
 
     return "".join(readings)

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -14,7 +14,7 @@ def test_to_reading() -> None:
         result = to_reading(equation)
         tobe = " ".join(
             [
-                "じゅうにまんさんせんよんひゃくごじゅうろく",
+                "じゅうにまんさんぜんよんひゃくごじゅうろく",
                 "かける",
                 "ななひゃくはちじゅうきゅう",
                 "いこーる",
@@ -22,3 +22,55 @@ def test_to_reading() -> None:
             ]
         )
         assert result == tobe
+
+
+def test_onbin() -> None:
+    equation = sympy.Number(8300)
+    result = to_reading(equation)
+    tobe = "はっせんさんびゃく"
+    assert result == tobe
+
+    equation = sympy.Number(3800)
+    result = to_reading(equation)
+    tobe = "さんぜんはっぴゃく"
+    assert result == tobe
+
+    equation = sympy.Number(3600)
+    result = to_reading(equation)
+    tobe = "さんぜんろっぴゃく"
+    assert result == tobe
+
+    equation = sympy.Number(10**12)
+    result = to_reading(equation)
+    tobe = "いっちょう"
+    assert result == tobe
+
+    equation = sympy.Number(6 * 10**12)
+    result = to_reading(equation)
+    tobe = "ろくちょう"
+    assert result == tobe
+
+    equation = sympy.Number(8 * 10**12)
+    result = to_reading(equation)
+    tobe = "はっちょう"
+    assert result == tobe
+
+    equation = sympy.Number(10**16)
+    result = to_reading(equation)
+    tobe = "いっけい"
+    assert result == tobe
+
+    equation = sympy.Number(6 * 10**16)
+    result = to_reading(equation)
+    tobe = "ろっけい"
+    assert result == tobe
+
+    equation = sympy.Number(8 * 10**16)
+    result = to_reading(equation)
+    tobe = "はっけい"
+    assert result == tobe
+
+    equation = sympy.Number(10**17)
+    result = to_reading(equation)
+    tobe = "じゅっけい"
+    assert result == tobe

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -55,6 +55,11 @@ def test_onbin() -> None:
     tobe = "はっちょう"
     assert result == tobe
 
+    equation = sympy.Number(10**13)
+    result = to_reading(equation)
+    tobe = "じゅっちょう"
+    assert result == tobe
+
     equation = sympy.Number(10**16)
     result = to_reading(equation)
     tobe = "いっけい"


### PR DESCRIPTION
Japanese has a phenomenon called "onbin" (音便) where the pronunciation
of a word changes to make it easier to say.

For example, 3000 is pronounced as "sansen" not "sansen"