### PR TITLE
Update coverage badge to Octocov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # sympy-reading
 
+![Coverage](https://raw.githubusercontent.com/kitsuyui/octocov-central/main/badges/kitsuyui/sympy-reading/coverage.svg)
+
 WIP


### PR DESCRIPTION
## Summary
- Replace or add Octocov coverage badge in README.
