### PR TITLE
Add Ruff McCabe complexity limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,6 @@ select = [
     "D",
     "S101",
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 1


### PR DESCRIPTION
## Summary
- add Ruff McCabe `max-complexity = 1`

## Testing
- `uv run poe check`
- `uv run poe test`

## Notes
- the existing `C901` ignore for `sympy_reading/__init__.py` is kept as-is
- `uv run poe build` currently fails because `build` is not installed in the project environment