### PR TITLE
Read all operands in associative expressions

### DIFF
--- a/sympy_reading/__init__.py
+++ b/sympy_reading/__init__.py
@@ -158,10 +158,9 @@ def expr_to_reading(expr: Expr) -> str:
 
     # Create the Japanese reading for the expression
     if expr.args:  # TODO: Currently support only infix notation
-        left = expr_to_reading(expr.args[0])
-        right = expr_to_reading(expr.args[1])
         op = component_to_reading(expr.func)
-        return f"{left} {op} {right}"
+        readings = [expr_to_reading(arg) for arg in expr.args]
+        return f" {op} ".join(readings)
 
     if expr.is_integer:
         return component_to_reading(expr)

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -32,6 +32,18 @@ def test_nested_expr() -> None:
         assert result == tobe
 
 
+def test_to_reading_with_three_operands() -> None:
+    with sympy.evaluate(False):
+        equation = sympy.Eq(sympy.Add(1, 2, 3), 6)
+        result = to_reading(equation)
+        assert result == "いち たす に たす さん いこーる ろく"
+
+    with sympy.evaluate(False):
+        equation = sympy.Eq(sympy.Mul(2, 3, 4), 24)
+        result = to_reading(equation)
+        assert result == "に かける さん かける よん いこーる にじゅうよん"
+
+
 def test_onbin() -> None:
     equation = sympy.Number(8300)
     result = to_reading(equation)


### PR DESCRIPTION
## Summary
- Read every operand in SymPy expressions instead of only the first two.
- Add regression coverage for 3-operand Add and Mul expressions.

## Verification
- uv run poe check
- uv run poe test
- git diff --check
