### PR TITLE
Document supported expression scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,25 @@
 
 ![Coverage](https://raw.githubusercontent.com/kitsuyui/octocov-central/main/badges/kitsuyui/sympy-reading/coverage.svg)
 
-WIP
+Convert a small subset of SymPy expressions into Japanese readings.
+
+## Supported expression scope
+
+This package currently supports a narrow, explicit subset:
+
+- non-negative SymPy integer constants;
+- `sympy.Add` and `sympy.Mul` expressions whose operands are recursively in
+  the supported subset;
+- `sympy.Eq` equations whose left and right sides are recursively in the
+  supported subset.
+
+`Add` is read as infix `たす`, `Mul` is read as infix `かける`, and `Eq` is
+read as `いこーる`.
+
+Use `sympy.evaluate(False)` or `evaluate=False` when an example must preserve
+numeric operators. Otherwise, SymPy may evaluate expressions such as
+`sympy.Add(1, 2)` before `to_reading()` sees the `Add` operation.
+
+Unsupported expressions raise `NotImplementedError`, including symbols,
+negative integers, rationals, floats, functions, powers, inequalities, and
+operators other than `Add` and `Mul`.

--- a/sympy_reading/__init__.py
+++ b/sympy_reading/__init__.py
@@ -144,7 +144,7 @@ def component_to_reading(component: Expr) -> str:
     for op_class, reading in OPERATOR_READING.items():
         if component is op_class:
             return reading
-    if component.is_integer:
+    if component.is_Integer and component >= 0:
         return digits_to_japanese(str(component))
     raise NotImplementedError(
         f"Unrecognized expr: {component}, type: {type(component)}",

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,3 +1,4 @@
+import pytest
 import sympy
 
 from sympy_reading import to_reading
@@ -42,6 +43,30 @@ def test_to_reading_with_three_operands() -> None:
         equation = sympy.Eq(sympy.Mul(2, 3, 4), 24)
         result = to_reading(equation)
         assert result == "に かける さん かける よん いこーる にじゅうよん"
+
+
+def test_supported_expression_scope_without_equation() -> None:
+    assert to_reading(sympy.Integer(0)) == "ぜろ"
+
+    with sympy.evaluate(False):
+        expression = sympy.Add(sympy.Integer(1), sympy.Mul(2, 3))
+        result = to_reading(expression)
+        assert result == "いち たす に かける さん"
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        sympy.Symbol("x"),
+        sympy.Symbol("n", integer=True),
+        sympy.Rational(1, 2),
+        sympy.Integer(-1),
+        sympy.Pow(2, 3, evaluate=False),
+    ],
+)
+def test_unsupported_expression_scope(expr) -> None:
+    with pytest.raises(NotImplementedError, match="Unrecognized expr"):
+        to_reading(expr)
 
 
 def test_onbin() -> None:


### PR DESCRIPTION
## Summary

- Replace the WIP README note with the currently supported expression scope.
- Add characterization tests for supported top-level expressions and unsupported boundary cases.
- Tighten integer handling so unsupported integer-like expressions raise `NotImplementedError` instead of leaking digit parsing errors.

## Validation

- `uv run poe format`
- `uv run poe check`
- `uv run pytest -q`
