### PR TITLE
Pin gitignore update action

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -13,4 +13,4 @@ jobs:
   update-gitignore:
     runs-on: ubuntu-latest
     steps:
-      - uses: gitignore-in/gh-action@v0.2.0
+      - uses: gitignore-in/gh-action@db0d41084ecac2da283378077c949750711e141e


### PR DESCRIPTION
## Summary
- Pin `gitignore-in/gh-action` in `.github/workflows/gitignore-in.yml` to the commit backing `v0.2.0`.
- Keep the scheduled gitignore update workflow behavior unchanged while avoiding a mutable action tag in a write-permission workflow.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gitignore-in.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/gitignore-in.yml`
- `actionlint .github/workflows/*.yml`
