### PR TITLE
Use reusable maintenance workflows

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -11,6 +11,4 @@ permissions:
 
 jobs:
   update-gitignore:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: gitignore-in/gh-action@db0d41084ecac2da283378077c949750711e141e
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,12 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Check spelling
-        uses: crate-ci/typos@master
-        # typos is a Source code spell checker
-        # https://github.com/crate-ci/typos
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main


### PR DESCRIPTION
## Summary
- Replace direct maintenance action invocations with reusable workflows from `kitsuyui/gh-actions-workflows`.
- Keep repository-specific triggers and permissions in the caller workflows.
- Split embedded spellcheck steps into a reusable spellcheck job where needed.

## Verification
- Parsed the changed workflow YAML files.
- Ran `actionlint` on the changed workflow files.
