### PR TITLE
Pin PyPI publish workflow actions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,14 +10,17 @@ on:
 env:
   python_version: 3.13
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Enable caching
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
         with:
           enable-cache: true
 
@@ -29,7 +32,7 @@ jobs:
         run: uv build
 
       - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
           user: __token__
@@ -38,7 +41,7 @@ jobs:
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Add explicit read-only `GITHUB_TOKEN` permissions to the PyPI packaging workflow.
- Pin the packaging workflow actions to immutable commit SHAs.
- Keep the existing TestPyPI/PyPI release conditions and token-based publishing configuration unchanged.

## Validation
- `git diff --check`
- Ruby YAML parse for `.github/workflows/pypi-publish.yml`
- `actionlint .github/workflows/pypi-publish.yml`
- `uv sync`
- `uv run poe check`
- `uv run poe test`
- `uv build`

## Notes
- Release publishing was not run locally.
- `uv build` completed successfully with existing setuptools/license warnings.
- `uv run poe build` currently fails before this change because the `build` module is not installed in the dev environment; the workflow uses `uv build` directly.
