### PR TITLE
Pin reusable workflow refs

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -7,4 +7,4 @@ permissions:
   issues: write
 jobs:
   happy:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc


### PR DESCRIPTION
## Summary

- Pin the reusable `happy-commit` workflow call to the current full commit SHA of `kitsuyui/gh-actions-workflows`
- Pin the reusable `gitignore-in` workflow call to the same immutable commit ref
- Keep the existing workflow permissions unchanged

## Validation

- `git diff --check`
- `actionlint .github/workflows/happy.yml .github/workflows/gitignore-in.yml`
- Verified both reusable workflow files exist at the pinned commit via the GitHub API
