### PR TITLE
Restrict test workflow token permissions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main


### PR DESCRIPTION
## Summary
- Add explicit read-only `GITHUB_TOKEN` permissions to the Python test workflow.
- Keep test, lint, and coverage jobs limited to repository contents reads.

## Verification
- `git diff --check`
- `actionlint .github/workflows/python-test.yml`