### PR TITLE
Pin remaining workflow actions to SHA

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   actionlint:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc # main
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -23,21 +23,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{ matrix.python }}"
 
       - name: Enable caching
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
         with:
           enable-cache: true
 
       - name: Enable caching and setup uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc # main


### PR DESCRIPTION
## Summary

- Replace mutable `@v5` / `@v6` / `@main` references in `python-test.yml` and `spellcheck.yml` with 40-char commit SHAs (and keep the original ref as a trailing comment).
- This matches the existing pinning style used in `octocov.yml` / `pypi-publish.yml` / `gitignore-in.yml` / `happy.yml`, so every external action reference in this repository is now SHA-pinned.

## Pinned references

| Reference | Pinned SHA |
| --- | --- |
| `actions/checkout@v5` | `93cb6efe18208431cddfb8368fd83d5badbf9bfd` |
| `actions/setup-python@v6` | `a309ff8b426b58ec0e2a45f0f869d46889d02405` |
| `astral-sh/setup-uv@v6` | `d0d8abe699bfb85fec6de9f7adb5ae17292296ff` |
| `kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main` | `3717c78af3a5e594b7a81b063276e15fac7e08fc` |
| `kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main` | `3717c78af3a5e594b7a81b063276e15fac7e08fc` |

## Test plan
- [ ] CI Test workflow (`python-test.yml`) passes
- [ ] CI Spellcheck workflow (`spellcheck.yml`) passes
- [ ] actionlint reports no issues