### PR TITLE
ci: make uv dependency caching explicit

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -35,13 +35,10 @@ jobs:
         with:
           python-version: "${{ matrix.python }}"
 
-      - name: Enable caching
+      - name: Set up uv
         uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
         with:
           enable-cache: true
-
-      - name: Enable caching and setup uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
## Summary
- remove the duplicate `setup-uv` step from the Python test workflow
- keep uv dependency caching enabled explicitly in the test workflow
- enable uv dependency caching explicitly in the octocov workflow

## Verification
- `actionlint`
- `git diff --check`
- `uv sync`
- `uv run poe check`
- `uv run ruff format --check sympy_reading tests`
- `uv run poe test`
- `uv run poe coverage-xml`
