### PR TITLE
fix: raise NotImplementedError for integers >= 10^72 in digits_to_japanese

### DIFF
--- a/sympy_reading/__init__.py
+++ b/sympy_reading/__init__.py
@@ -122,6 +122,14 @@ def digits_to_japanese(digits_str: str, top: bool = True) -> str:
         reading = scale_reading_1_japanese(digits_str[0], len(digits_str) - 2)
         return f"{reading}{digits_to_japanese(digits_str[1:], top=False)}"
 
+    if len(digits_str) > len(SCALE_READING_2) * 4:
+        raise NotImplementedError(
+            f"digits_to_japanese supports integers up to "
+            f"{len(SCALE_READING_2) * 4} digits "
+            f"(< 10^{len(SCALE_READING_2) * 4}); "
+            f"got {len(digits_str)} digits.",
+        )
+
     # Split the digits into groups of 4 from right to left
     digits_array = []
     for i in range(0, len(digits_str), 4):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -69,6 +69,16 @@ def test_unsupported_expression_scope(expr) -> None:
         to_reading(expr)
 
 
+def test_large_number_raises_not_implemented() -> None:
+    # 10^72 has 73 digits, exceeding the 72-digit (18 groups x 4) limit.
+    with pytest.raises(NotImplementedError):
+        to_reading(sympy.Integer(10**72))
+
+    # 10^72 - 1 is the maximum supported (72 digits = むりょうたいすう scale).
+    result = to_reading(sympy.Integer(10**68))
+    assert result == "いちむりょうたいすう"
+
+
 def test_onbin() -> None:
     equation = sympy.Number(8300)
     result = to_reading(equation)


### PR DESCRIPTION
## Summary

`digits_to_japanese` raises `IndexError` instead of `NotImplementedError` for
integers with 73 or more digits (≥ 10^72).

`SCALE_READING_2` has 18 entries (indices 0–17). A 73-digit number requires 19
groups of four digits, which accesses index 18 and triggers an out-of-bounds
`IndexError`. The documented behavior for unsupported input is
`NotImplementedError`.

## Change

- Add a guard in `digits_to_japanese` before the group-split loop: if
  `len(digits_str) > len(SCALE_READING_2) * 4` (i.e. > 72 digits), raise
  `NotImplementedError` with an informative message.
- Add `test_large_number_raises_not_implemented` to verify:
  - `to_reading(sympy.Integer(10**72))` raises `NotImplementedError`
  - `to_reading(sympy.Integer(10**68))` succeeds (boundary case, 69 digits)

## Verification

```
uv run poe check   # ruff lint — all checks passed
uv run poe test    # 11 passed
```
