### PR TITLE
Warn when reading evaluated scalar expressions

### DIFF
--- a/sympy_reading/__init__.py
+++ b/sympy_reading/__init__.py
@@ -1,11 +1,19 @@
 # TODO: Support more complex expressions
 # TODO: Support other languages
 
+import warnings
 from types import MappingProxyType
 
 from sympy import Add, Eq, Expr, Integer, Mul
+from sympy.core.parameters import global_parameters
+from sympy.logic.boolalg import BooleanAtom
 
 __all__ = ["to_reading"]
+
+
+class ExpressionEvaluationWarning(UserWarning):
+    """Warns that SymPy may have evaluated an input before reading it."""
+
 
 DIGIT_READING = MappingProxyType(
     {
@@ -210,16 +218,48 @@ def equation_to_reading(eq: Eq) -> str:
     return f"{left_reading} いこーる {right_reading}"
 
 
-def to_reading(expr: Add | Eq | Integer | Mul) -> str:
+def warn_if_scalar_may_be_evaluated(expr: Expr) -> None:
+    if not expr.is_Integer:
+        return
+    if expr < 0:
+        return
+    if not global_parameters.evaluate:
+        return
+    warnings.warn(
+        "to_reading() received an integer while SymPy evaluation is enabled. "
+        "If this value came from an expression such as sympy.Add(1, 2), "
+        "SymPy may have evaluated it before to_reading() could read the "
+        "operator structure. Use sympy.evaluate(False) or evaluate=False to "
+        "preserve numeric operators.",
+        ExpressionEvaluationWarning,
+        stacklevel=2,
+    )
+
+
+def raise_evaluated_boolean_error(expr: BooleanAtom) -> None:
+    raise NotImplementedError(
+        f"Unrecognized evaluated boolean: {expr}. "
+        "SymPy may have evaluated an equation before to_reading() could read "
+        "its left and right sides. Use sympy.evaluate(False) or "
+        "sympy.Eq(..., evaluate=False) to preserve the equation structure.",
+    )
+
+
+def to_reading(expr: Add | BooleanAtom | Eq | Integer | Mul) -> str:
     """
     Convert the supported SymPy subset into a Japanese reading.
 
     Supported inputs are non-negative integers, Add/Mul expressions whose
     operands are supported, and Eq equations whose sides are supported.
-    Unsupported expressions raise NotImplementedError.
+    An evaluated boolean (e.g. ``Eq(1, 1)`` under SymPy evaluation) raises
+    NotImplementedError with guidance to disable evaluation. Other
+    unsupported expressions also raise NotImplementedError.
     """
     if isinstance(expr, Eq):
         return equation_to_reading(expr)
+    if isinstance(expr, BooleanAtom):
+        raise_evaluated_boolean_error(expr)
     if isinstance(expr, Expr):
+        warn_if_scalar_may_be_evaluated(expr)
         return expr_to_reading(expr)
     raise NotImplementedError(f"Unrecognized expr: {expr}, type: {type(expr)}")

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -2,9 +2,10 @@ from typing import get_args, get_type_hints
 
 import pytest
 import sympy
+from sympy.logic.boolalg import BooleanAtom
 
 import sympy_reading
-from sympy_reading import to_reading
+from sympy_reading import ExpressionEvaluationWarning, to_reading
 
 
 def test_to_reading() -> None:
@@ -49,7 +50,8 @@ def test_to_reading_with_three_operands() -> None:
 
 
 def test_supported_expression_scope_without_equation() -> None:
-    assert to_reading(sympy.Integer(0)) == "ぜろ"
+    with sympy.evaluate(False):
+        assert to_reading(sympy.Integer(0)) == "ぜろ"
 
     with sympy.evaluate(False):
         expression = sympy.Add(sympy.Integer(1), sympy.Mul(2, 3))
@@ -72,6 +74,7 @@ def test_to_reading_type_hint_matches_supported_root_scope() -> None:
 
     assert accepted_types == {
         sympy.Add,
+        BooleanAtom,
         sympy.Eq,
         sympy.Integer,
         sympy.Mul,
@@ -90,6 +93,18 @@ def test_public_exports_and_internal_tables_are_stable() -> None:
         sympy_reading.SCALE_READING_2.append("extra")  # type: ignore[attr-defined]
     with pytest.raises(TypeError):
         sympy_reading.OPERATOR_READING[sympy.Add] = "plus"  # type: ignore[index]
+
+
+def test_evaluated_scalar_warns_about_lost_structure() -> None:
+    with pytest.warns(ExpressionEvaluationWarning, match="evaluated"):
+        result = to_reading(sympy.Add(1, 2))
+
+    assert result == "さん"
+
+
+def test_evaluated_equation_error_mentions_evaluate_false() -> None:
+    with pytest.raises(NotImplementedError, match="evaluated boolean"):
+        to_reading(sympy.Eq(1, 1))
 
 
 @pytest.mark.parametrize(
@@ -119,55 +134,56 @@ def test_large_number_raises_not_implemented() -> None:
 
 
 def test_onbin() -> None:
-    equation = sympy.Number(8300)
-    result = to_reading(equation)
-    tobe = "はっせんさんびゃく"
-    assert result == tobe
+    with sympy.evaluate(False):
+        equation = sympy.Number(8300)
+        result = to_reading(equation)
+        tobe = "はっせんさんびゃく"
+        assert result == tobe
 
-    equation = sympy.Number(3800)
-    result = to_reading(equation)
-    tobe = "さんぜんはっぴゃく"
-    assert result == tobe
+        equation = sympy.Number(3800)
+        result = to_reading(equation)
+        tobe = "さんぜんはっぴゃく"
+        assert result == tobe
 
-    equation = sympy.Number(3600)
-    result = to_reading(equation)
-    tobe = "さんぜんろっぴゃく"
-    assert result == tobe
+        equation = sympy.Number(3600)
+        result = to_reading(equation)
+        tobe = "さんぜんろっぴゃく"
+        assert result == tobe
 
-    equation = sympy.Number(10**12)
-    result = to_reading(equation)
-    tobe = "いっちょう"
-    assert result == tobe
+        equation = sympy.Number(10**12)
+        result = to_reading(equation)
+        tobe = "いっちょう"
+        assert result == tobe
 
-    equation = sympy.Number(6 * 10**12)
-    result = to_reading(equation)
-    tobe = "ろくちょう"
-    assert result == tobe
+        equation = sympy.Number(6 * 10**12)
+        result = to_reading(equation)
+        tobe = "ろくちょう"
+        assert result == tobe
 
-    equation = sympy.Number(8 * 10**12)
-    result = to_reading(equation)
-    tobe = "はっちょう"
-    assert result == tobe
+        equation = sympy.Number(8 * 10**12)
+        result = to_reading(equation)
+        tobe = "はっちょう"
+        assert result == tobe
 
-    equation = sympy.Number(10**13)
-    result = to_reading(equation)
-    tobe = "じゅっちょう"
-    assert result == tobe
+        equation = sympy.Number(10**13)
+        result = to_reading(equation)
+        tobe = "じゅっちょう"
+        assert result == tobe
 
-    equation = sympy.Number(10**16)
-    result = to_reading(equation)
-    tobe = "いっけい"
-    assert result == tobe
+        equation = sympy.Number(10**16)
+        result = to_reading(equation)
+        tobe = "いっけい"
+        assert result == tobe
 
-    equation = sympy.Number(6 * 10**16)
-    result = to_reading(equation)
-    tobe = "ろっけい"
-    assert result == tobe
+        equation = sympy.Number(6 * 10**16)
+        result = to_reading(equation)
+        tobe = "ろっけい"
+        assert result == tobe
 
-    equation = sympy.Number(8 * 10**16)
-    result = to_reading(equation)
-    tobe = "はっけい"
-    assert result == tobe
+        equation = sympy.Number(8 * 10**16)
+        result = to_reading(equation)
+        tobe = "はっけい"
+        assert result == tobe
 
     equation = sympy.Number(10**17)
     result = to_reading(equation)


### PR DESCRIPTION
## Summary
- Add an explicit warning when `to_reading()` receives a non-negative integer while SymPy evaluation is enabled, so evaluated inputs such as `sympy.Add(1, 2)` are no longer silent.
- Add a clearer `NotImplementedError` for evaluated boolean equations such as `sympy.Eq(1, 1)`, with guidance to preserve structure via `sympy.evaluate(False)` or `evaluate=False`.
- Cover both evaluated-input cases in tests.

## Validation
- `uv run poe format`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
