### PR TITLE
Add py.typed marker and enable mypy type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ coverage-xml = "pytest --cov=sympy_reading --doctest-modules --cov-report=xml"
 format = "ruff format sympy_reading tests"
 check = [
     { cmd = "ruff check sympy_reading tests" },
-    # { cmd = "mypy sympy_reading tests" },
+    { cmd = "mypy sympy_reading tests" },
 ]
 build = "python -m build"
 
@@ -107,3 +107,10 @@ select = [
 
 [tool.ruff.lint.mccabe]
 max-complexity = 1
+
+[tool.mypy]
+python_version = "3.10"
+
+[[tool.mypy.overrides]]
+module = "sympy.*"
+ignore_missing_imports = true

--- a/sympy_reading/__init__.py
+++ b/sympy_reading/__init__.py
@@ -123,7 +123,7 @@ def digits_to_japanese(digits_str: str, top: bool = True) -> str:
         return f"{reading}{digits_to_japanese(digits_str[1:], top=False)}"
 
     # Split the digits into groups of 4 from right to left
-    digits_array = []
+    digits_array: list[str] = []
     for i in range(0, len(digits_str), 4):
         cut = digits_str[-(i + 4) : len(digits_str) - i]
         if cut:


### PR DESCRIPTION
## Summary

The package declared `sympy_reading/py.typed` and `*.pyi` in `package-data`, but the `py.typed` file was absent from the package directory. Per PEP 561, the marker file must exist for downstream type checkers to treat the package as typed.

Additionally, `mypy` was listed as a dev dependency but commented out of the `check` task, so type errors were not caught in CI.

**Changes:**
- Add `sympy_reading/py.typed` (empty PEP 561 marker file)
- Uncomment `mypy sympy_reading tests` in the `check` poe task
- Add `[tool.mypy]` configuration with `[[tool.mypy.overrides]]` for `sympy.*` (which does not ship type stubs)
- Add explicit `list[str]` annotation for `digits_array` to satisfy mypy's `var-annotated` check

## Verification

```
$ uv run mypy sympy_reading tests
Success: no issues found in 3 source files

$ uv run pytest
10 passed in 0.17s
```

## Trade-offs

Enabling strict type checking on CI may surface new errors if sympy's API signatures change in future releases. The `[[tool.mypy.overrides]]` section limits noise to only sympy-internal calls by ignoring missing stubs for that library specifically, rather than suppressing all import errors globally.