### PR TITLE
fix: align expr_to_reading dispatch condition with component_to_reading

### DIFF
--- a/sympy_reading/__init__.py
+++ b/sympy_reading/__init__.py
@@ -162,7 +162,7 @@ def expr_to_reading(expr: Expr) -> str:
         readings = [expr_to_reading(arg) for arg in expr.args]
         return f" {op} ".join(readings)
 
-    if expr.is_integer:
+    if expr.is_Integer:
         return component_to_reading(expr)
 
     raise NotImplementedError(f"Unrecognized expr: {expr}, type: {type(expr)}")

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -62,6 +62,7 @@ def test_supported_expression_scope_without_equation() -> None:
         sympy.Rational(1, 2),
         sympy.Integer(-1),
         sympy.Pow(2, 3, evaluate=False),
+        sympy.Float(3.0),  # is_integer=True but is_Integer=False
     ],
 )
 def test_unsupported_expression_scope(expr) -> None:


### PR DESCRIPTION
## Summary

Fix a dispatch mismatch in `expr_to_reading` where the guard condition used `expr.is_integer` (lowercase) but the callee `component_to_reading` required `component.is_Integer` (uppercase).

In SymPy, `is_integer` tests whether an expression *has an integer value*, while `is_Integer` tests whether it *is a SymPy `Integer` instance*. `sympy.Float(3.0)` satisfies `is_integer=True` but `is_Integer=False`. Under the old code, `Float(3.0)` was dispatched to `component_to_reading` but was then rejected there with a `NotImplementedError` whose message pointed at the wrong layer — obscuring that the dispatch itself was the fault.

## Changes

- `sympy_reading/__init__.py`: change `if expr.is_integer:` → `if expr.is_Integer:` in `expr_to_reading` to match the acceptance criterion of `component_to_reading`
- `tests/test_basis.py`: add `sympy.Float(3.0)` to `test_unsupported_expression_scope` as a regression guard

## Verification

- `uv run poe check` — all checks passed
- `uv run poe test` — 11/11 tests pass (including the new Float(3.0) case)

## Trade-offs

`Float(3.0)` is now consistently rejected at `expr_to_reading` rather than being silently dispatched to a deeper layer that also rejects it. Integer-valued Float expressions are not a supported use case; callers that need integer-value conversion can use `sympy.Integer(int(expr))` before passing to `to_reading`.
