### PR TITLE
Narrow sympy_reading supported input annotations

### DIFF
--- a/sympy_reading/__init__.py
+++ b/sympy_reading/__init__.py
@@ -2,7 +2,7 @@
 # TODO: Support other languages
 
 import sympy
-from sympy import Eq, Expr
+from sympy import Add, Eq, Expr, Integer, Mul
 
 DIGIT_READING = {
     "0": "ぜろ",
@@ -123,7 +123,7 @@ def digits_to_japanese(digits_str: str, top: bool = True) -> str:
         return f"{reading}{digits_to_japanese(digits_str[1:], top=False)}"
 
     # Split the digits into groups of 4 from right to left
-    digits_array = []
+    digits_array: list[str] = []
     for i in range(0, len(digits_str), 4):
         cut = digits_str[-(i + 4) : len(digits_str) - i]
         if cut:
@@ -139,8 +139,13 @@ def digits_to_japanese(digits_str: str, top: bool = True) -> str:
     return "".join(readings)
 
 
-# Convert equation components to their Japanese readings
-def component_to_reading(component: Expr) -> str:
+def component_to_reading(component: Integer | type[Add] | type[Mul]) -> str:
+    """
+    Convert a supported leaf component or operator class.
+
+    Supported components are non-negative integers and the Add/Mul operator
+    classes used while recursively reading supported expressions.
+    """
     for op_class, reading in OPERATOR_READING.items():
         if component is op_class:
             return reading
@@ -151,9 +156,13 @@ def component_to_reading(component: Expr) -> str:
     )
 
 
-def expr_to_reading(expr: Expr) -> str:
+def expr_to_reading(expr: Add | Integer | Mul) -> str:
     """
-    Convert a SymPy expression into its Japanese reading.
+    Convert a supported SymPy expression into its Japanese reading.
+
+    Supported expressions are non-negative integers and Add/Mul expressions
+    whose operands are also supported. Other SymPy expressions raise
+    NotImplementedError.
     """
 
     # Create the Japanese reading for the expression
@@ -180,7 +189,14 @@ def equation_to_reading(eq: Eq) -> str:
     return f"{left_reading} いこーる {right_reading}"
 
 
-def to_reading(expr: Eq | Expr) -> str:
+def to_reading(expr: Add | Eq | Integer | Mul) -> str:
+    """
+    Convert the supported SymPy subset into a Japanese reading.
+
+    Supported inputs are non-negative integers, Add/Mul expressions whose
+    operands are supported, and Eq equations whose sides are supported.
+    Unsupported expressions raise NotImplementedError.
+    """
     if isinstance(expr, Eq):
         return equation_to_reading(expr)
     if isinstance(expr, Expr):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,6 +1,9 @@
+from typing import get_args, get_type_hints
+
 import pytest
 import sympy
 
+import sympy_reading
 from sympy_reading import to_reading
 
 
@@ -52,6 +55,19 @@ def test_supported_expression_scope_without_equation() -> None:
         expression = sympy.Add(sympy.Integer(1), sympy.Mul(2, 3))
         result = to_reading(expression)
         assert result == "いち たす に かける さん"
+
+
+def test_to_reading_type_hint_matches_supported_root_scope() -> None:
+    hints = get_type_hints(sympy_reading.to_reading)
+    accepted_types = set(get_args(hints["expr"]))
+
+    assert accepted_types == {
+        sympy.Add,
+        sympy.Eq,
+        sympy.Integer,
+        sympy.Mul,
+    }
+    assert sympy.Expr not in accepted_types
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Summary:
- narrow public input annotations to the SymPy node types currently supported by the reader
- document the supported expression subset in conversion helper docstrings
- add a regression test that verifies the public root annotation excludes generic Expr

Checks:
- uv run poe check
- uv run poe test
- uv run poe coverage-xml
- uv run ruff format --check sympy_reading tests
- uv run mypy --ignore-missing-imports sympy_reading tests
- uv build
- git diff --check

Note: uv build emitted existing setuptools/license warnings, but completed successfully.
