### PR TITLE
chore: align GitHub Actions SHAs to checkout v6 and setup-uv v7

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -21,10 +21,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Enable caching
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
         id: setup-python
@@ -36,7 +36,7 @@ jobs:
           python-version: "${{ matrix.python }}"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 


### PR DESCRIPTION
## Summary

Three workflows used different pinned SHAs for the same GitHub Actions:

| Workflow | `actions/checkout` | `astral-sh/setup-uv` |
|---|---|---|
| `python-test.yml` | v5 | v6 |
| `pypi-publish.yml` | v5 (no comment) | unknown (no comment) |
| `octocov.yml` | v6 | v7 |

This version drift means the test environment (v6 UV) and the build environment (unknown UV version) may resolve dependencies differently, reducing reproducibility guarantees between CI jobs.

## Changes

Align `python-test.yml` and `pypi-publish.yml` to use the same SHAs already in `octocov.yml`:

- `actions/checkout`: `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6)
- `astral-sh/setup-uv`: `37802adc94f370d6bfd71619e3f0bf239e1f3b78` (v7)

Version comments are added where they were missing.

## Verification

`actionlint` reports no issues on the modified files.

## Trade-offs

Updating `actions/checkout` from v5 to v6 changes the default `fetch-depth` from `1` to `1` (no change in this regard), but v6 adds native support for sparse checkouts and other improvements. No behavioral regressions are expected for this repository's use case.
