### PR TITLE
ci: add deployment environments to PyPI publish jobs

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,8 +18,29 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+
+      - name: Enable caching
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        with:
+          enable-cache: true
+
+      - run: |
+          uv python pin ${{ env.python_version }}
+          uv sync
+
+      - name: Build
+        run: uv build
+
+  publish-test-pypi:
+    name: Publish distribution to Test PyPI
+    if: github.event_name == 'release' && github.event.release.prerelease
+    needs: build
+    runs-on: ubuntu-latest
+    environment: test-pypi
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
@@ -37,14 +58,33 @@ jobs:
 
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        if: github.event_name == 'release' && github.event.release.prerelease
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
+  publish-pypi:
+    name: Publish distribution to PyPI
+    if: github.event_name == 'release' && !github.event.release.prerelease
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+
+      - name: Enable caching
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        with:
+          enable-cache: true
+
+      - run: |
+          uv python pin ${{ env.python_version }}
+          uv sync
+
+      - name: Build
+        run: uv build
+
       - name: Publish distribution to PyPI
-        if: github.event_name == 'release' && !github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           user: __token__


### PR DESCRIPTION
## Summary
- split the packaging workflow into a build job and release-only publish jobs
- attach `test-pypi` and `pypi` environments to the corresponding publish jobs
- keep pull request packaging checks free of deployment environment gates

## Checks
- `uv run poe check`
- `uv run poe test`
- `uv build`
- `actionlint`
- `git diff --check`
- implement-validator foreground gate: overall pass
