### PR TITLE
ci: enforce minimum coverage threshold

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,5 +1,6 @@
 # https://github.com/k1LoW/octocov?tab=readme-ov-file#configuration
 coverage:
+  acceptable: 98%
   paths:
     - coverage.xml
 codeToTestRatio:


### PR DESCRIPTION
## Summary

Add an absolute octocov coverage threshold so CI can fail when coverage drops below the current baseline.

The threshold is set to `98%`, below the current measured `99.0%` coverage, so the current test suite passes while future coverage regressions become blocking.

## Verification

- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `go run github.com/k1LoW/octocov@latest --config .octocov.yml`
- `uvx vulture sympy_reading tests`
- `git diff --check`
- implement-validator: `overall: pass`
