### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,31 @@ numeric operators. Otherwise, SymPy may evaluate expressions such as
 Unsupported expressions raise `NotImplementedError`, including symbols,
 negative integers, rationals, floats, functions, powers, inequalities, and
 operators other than `Add` and `Mul`.
+
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install dependencies
+uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `uv run poe check`
+- **pre-push**: `uv run poe check` and `uv run poe test`
+
+You can also run the checks manually:
+
+```sh
+uv run poe check
+uv run poe test
+```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` so contributors can run the same checks as CI locally
- CI (GitHub Actions) is kept entirely unchanged — Actions remain free for public repos; the hooks only surface problems earlier on the developer's machine

## Changes

- `lefthook.yml`: configures a `pre-commit` hook that runs `uv run poe check`, and a `pre-push` hook that runs both `uv run poe check` and `uv run poe test`
- `README.md`: adds a `## Development` section documenting how to install lefthook and what the hooks do

## Verification

- `uv run poe check` passes on current code (ruff: all checks passed)
- `uv run poe test` passes on current code (11 passed)
- `lefthook install` installed the hooks; the pre-commit hook fired and passed during the commit
- The pre-push hook fired (`check` + `test`) and passed during `git push`

## Notes

- Requires `lefthook` on your `PATH` (`brew install lefthook` or see https://lefthook.dev/)
- No CI workflows were modified
