### PR TITLE
ci: migrate PyPI publish to OIDC Trusted Publisher

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -41,6 +41,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: test-pypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
@@ -59,8 +62,6 @@ jobs:
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
   publish-pypi:
@@ -69,6 +70,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
@@ -86,6 +90,3 @@ jobs:
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

Replace long-lived API token authentication with short-lived OIDC credentials via [PyPI Trusted Publisher](https://docs.pypi.org/trusted-publishers/) (GitHub Actions OIDC).

Long-lived `PYPI_API_TOKEN` / `TEST_PYPI_API_TOKEN` secrets remain valid until explicitly revoked. If either secret leaks, an attacker can publish arbitrary releases until the token is revoked. OIDC Trusted Publisher eliminates this risk: PyPI issues a short-lived credential tied to the specific workflow run, and no secret needs to be stored in the repository.

## Changes

- `publish-test-pypi`, `publish-pypi`: add `permissions: id-token: write`
- `publish-test-pypi`, `publish-pypi`: remove `user: __token__` and `password: ${{ secrets.xxx }}` — `pypa/gh-action-pypi-publish` auto-detects OIDC when no token is provided

## Prerequisites before merging

The following manual steps on PyPI are required **before this PR is merged** (otherwise the next release will fail):

1. **PyPI** — go to https://pypi.org/manage/account/publishing/, add a Trusted Publisher:
   - Publisher: GitHub Actions
   - Owner: `kitsuyui`
   - Repository name: `sympy-reading`
   - Workflow name: `pypi-publish.yml`
   - Environment name: `pypi`

2. **Test PyPI** — same steps on https://test.pypi.org/manage/account/publishing/, environment name: `test-pypi`

3. After both Trusted Publishers are active, the `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` secrets can be removed from the repository settings.

## Verification

- `actionlint .github/workflows/pypi-publish.yml`: no errors
- collateral check: clean
- No functional change on PR or non-release events (jobs are gated on `release` events)
