### PR TITLE
ci: set persist-credentials: false on all actions/checkout steps

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: install shared libraries
         run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Enable caching
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -43,6 +45,8 @@ jobs:
     environment: test-pypi
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
 
       - name: Enable caching
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
@@ -71,6 +75,8 @@ jobs:
     environment: pypi
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
 
       - name: Enable caching
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e


### PR DESCRIPTION
## Summary

Without `persist-credentials: false`, `actions/checkout` leaves the GITHUB_TOKEN git credential in `~/.git-credentials` for the lifetime of the job. For jobs with elevated permissions this expands the attack surface for supply-chain attacks via transitive build dependencies.

## Changes

- `octocov.yml`: added `persist-credentials: false` to the `actions/checkout` step (job has `pull-requests: write` and `checks: write` permissions)
- `pypi-publish.yml`: added `persist-credentials: false` to `actions/checkout` in all three jobs (`build`, `publish-test-pypi`, `publish-pypi`)

## Verification

- `actionlint` reports no issues on both modified workflow files
- No Python source changes; format/lint/test scope unaffected
- Collateral check: clean (no `gha-inline-script`, `version-shrink`, `too-many-files`, or `breaking-suspect` findings)