### PR TITLE
ci: pin shared Renovate presets

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>kitsuyui/renovate-config"
+    "config:recommended",
+    ":dependencyDashboard",
+    "default:pinDigestsDisabled",
+    "local>kitsuyui/renovate-config:npm.json5#cdad3c71e34e5abadf909c996906011bbc2b5725",
+    "local>kitsuyui/renovate-config:python.json5#cdad3c71e34e5abadf909c996906011bbc2b5725",
+    "local>kitsuyui/renovate-config:cargo.json5#cdad3c71e34e5abadf909c996906011bbc2b5725",
+    "local>kitsuyui/renovate-config:gha.json5#cdad3c71e34e5abadf909c996906011bbc2b5725",
+    "local>kitsuyui/renovate-config:pin.json5#cdad3c71e34e5abadf909c996906011bbc2b5725",
+    "local>kitsuyui/renovate-config:lockfile.json5#cdad3c71e34e5abadf909c996906011bbc2b5725"
+  ],
+  "git-submodules": {
+    "enabled": true
+  },
+  "timezone": "Asia/Tokyo",
+  "schedule": [
+    "before 9am every weekday",
+    "every weekend"
   ]
 }


### PR DESCRIPTION
Summary
- Pin shared Renovate presets to the fixed `kitsuyui/renovate-config` commit and expand the config inline with the built-in preset stack.
- Keep the existing schedule, timezone, and git submodule handling explicit in the repository config.

Verification
- `RENOVATE_TOKEN=$(gh auth token) npx --yes --package renovate renovate-config-validator --strict --no-global .github/renovate.json5`
- `npx --yes json5 .github/renovate.json5`
- `git diff --check`
- `actionlint .github/workflows/*.yml`
- `uv sync`
- `uv run poe check`
- `uv run ruff format --check sympy_reading tests`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- collateral check clean

Notes
- `uv build` succeeded and emitted existing setuptools/license metadata warnings about the project license field and missing `LICENSE` file.
